### PR TITLE
defaultMenuIconSimplification

### DIFF
--- a/Commander-Activators-ContextMenu.package/CmdCommand.extension/instance/setUpIconForMenuItem..st
+++ b/Commander-Activators-ContextMenu.package/CmdCommand.extension/instance/setUpIconForMenuItem..st
@@ -1,2 +1,5 @@
 *Commander-Activators-ContextMenu
 setUpIconForMenuItem: aMenuItemMorph
+
+	self defaultMenuIcon ifNotNil: [:icon |
+		aMenuItemMorph icon: icon ]

--- a/Commander-Core.package/CmdCommand.class/class/defaultMenuIconName.st
+++ b/Commander-Core.package/CmdCommand.class/class/defaultMenuIconName.st
@@ -1,0 +1,6 @@
+accessing
+defaultMenuIconName
+	"Not really nice to return nil. But it is already expected by many tools.
+	So it is easy to allow nil.
+	But users should use instance side method defaultMenuIcon which should Form instance"
+	^nil

--- a/Commander-Core.package/CmdCommand.class/instance/defaultMenuIcon.st
+++ b/Commander-Core.package/CmdCommand.class/instance/defaultMenuIcon.st
@@ -1,0 +1,4 @@
+accessing
+defaultMenuIcon
+	^self class defaultMenuIconName ifNotNil: [ :iconName | 
+		Smalltalk ui iconNamed: iconName ]

--- a/Commander-Core.package/CmdCommand.class/instance/secureMenuIcon.st
+++ b/Commander-Core.package/CmdCommand.class/instance/secureMenuIcon.st
@@ -1,0 +1,7 @@
+accessing
+secureMenuIcon
+	"In case when icon should be mandatory property of command
+	users should call this method. It ensure Form instance 
+	which will indicate missing icon as a problem"
+	
+	^self defaultMenuIcon ifNil: [ Smalltalk ui iconNamed: #error ]

--- a/Commander-Core.package/CmdCommandActivator.class/instance/menuItemIcon.st
+++ b/Commander-Core.package/CmdCommandActivator.class/instance/menuItemIcon.st
@@ -1,0 +1,3 @@
+accessing
+menuItemIcon
+	^self command defaultMenuIcon

--- a/Commander-Examples.package/CmdAddContactCommand.class/properties.json
+++ b/Commander-Examples.package/CmdAddContactCommand.class/properties.json
@@ -1,5 +1,5 @@
 {
-	"commentStamp" : "DenisKudryashov 12/20/2017 17:05",
+	"commentStamp" : "",
 	"super" : "CmdCommand",
 	"category" : "Commander-Examples",
 	"classinstvars" : [ ],

--- a/Commander-Examples.package/CmdRemoveContactCommand.class/class/defaultMenuIconName.st
+++ b/Commander-Examples.package/CmdRemoveContactCommand.class/class/defaultMenuIconName.st
@@ -1,0 +1,3 @@
+accessing
+defaultMenuIconName
+	^#removeIcon

--- a/Commander-Examples.package/CmdRemoveContactCommand.class/instance/setUpIconForMenuItem..st
+++ b/Commander-Examples.package/CmdRemoveContactCommand.class/instance/setUpIconForMenuItem..st
@@ -1,3 +1,0 @@
-initialization
-setUpIconForMenuItem: aMenuItemMorph
-	self setUpIconNamed: #removeIcon forMenuItem: aMenuItemMorph


### PR DESCRIPTION
Now any command understand defaultMenuIcon which by default ask uses icon name from class side (defaultMenuIconName).
They both can return nil which is default value.

Also additional method is added for the cases when real icon instance should be ensured: #secureMenuIcon. In case if missin icon it returnes error icon.

And CmdCommandActivator is now understands menuItemIcon.
All commands are adopted to this simplification