### PR TITLE
reusableSettingBuilding

### DIFF
--- a/Commander-Activators-Shortcut.package/CmdShortcutCommandActivation.class/class/buildSettingNodeFor.on..st
+++ b/Commander-Activators-Shortcut.package/CmdShortcutCommandActivation.class/class/buildSettingNodeFor.on..st
@@ -1,7 +1,0 @@
-settings
-buildSettingNodeFor: aShortcutActivation on: aBuilder
-
-	| nodeBuilder |
-	nodeBuilder := aBuilder 
-		nodeClass: CmdShortcutSetting name: aShortcutActivation id.
-	nodeBuilder node item shortcutActivation: aShortcutActivation

--- a/Commander-Activators-Shortcut.package/CmdShortcutCommandActivation.class/class/buildSettingsFor.on..st
+++ b/Commander-Activators-Shortcut.package/CmdShortcutCommandActivation.class/class/buildSettingsFor.on..st
@@ -2,4 +2,4 @@ settings
 buildSettingsFor: activations on: aBuilder
 	| sorted |
 	sorted := activations sorted: [ :a :b | a commandClass name <= b commandClass name ].
-	sorted do: [ :each |	self buildSettingNodeFor: each on: aBuilder]
+	sorted do: [ :each |	each buildSettingNodeOn: aBuilder]

--- a/Commander-Activators-Shortcut.package/CmdShortcutCommandActivation.class/instance/buildSettingNodeOn..st
+++ b/Commander-Activators-Shortcut.package/CmdShortcutCommandActivation.class/instance/buildSettingNodeOn..st
@@ -1,0 +1,7 @@
+settings
+buildSettingNodeOn: aBuilder
+	| nodeBuilder |
+	nodeBuilder := aBuilder 
+		nodeClass: CmdShortcutSetting name: self id.
+	nodeBuilder node item shortcutActivation: self.
+	^nodeBuilder

--- a/Commander-Activators-Shortcut.package/CmdShortcutSetting.class/instance/markRedefinedStatus.st
+++ b/Commander-Activators-Shortcut.package/CmdShortcutSetting.class/instance/markRedefinedStatus.st
@@ -1,4 +1,5 @@
 updating
 markRedefinedStatus
-	label := shortcutActivation id.
+	(label beginsWith: '*') ifTrue: [label := label allButFirst].
+	
 	shortcutActivation isRedefined ifTrue: [ label := '*', label ]

--- a/Commander-Activators-Shortcut.package/CmdShortcutSetting.class/instance/shortcutActivation..st
+++ b/Commander-Activators-Shortcut.package/CmdShortcutSetting.class/instance/shortcutActivation..st
@@ -2,5 +2,6 @@ accessing
 shortcutActivation: aShortcutActivation
 	shortcutActivation := aShortcutActivation.
 	
+	label := shortcutActivation id.
+	description := shortcutActivation commandClass comment.
 	self markRedefinedStatus.
-	description := shortcutActivation commandClass comment


### PR DESCRIPTION
buildSettingNodeOn: is moved to shortcut activation (instance side).
So it is now reusable and you can put concrete shortuct settings into custom settings group. For example

	((ClyOpenSpotterMenuCommand classAnnotationAt: #browserShortcutActivation) buildSettingNodeOn: builder)
		label: 'open spotter menu';
		description: 'some description'