### PR TITLE
branchToSaveCodeWhileIcebergFail

### DIFF
--- a/Commander-Activators-ContextMenu.package/CmdCommand.extension/instance/registerContextMenuItemsFor.withBuilder..st
+++ b/Commander-Activators-ContextMenu.package/CmdCommand.extension/instance/registerContextMenuItemsFor.withBuilder..st
@@ -1,10 +1,14 @@
 *Commander-Activators-ContextMenu
 registerContextMenuItemsFor: aCommandItem withBuilder: aBuilder
-	| item |
-	
+	| item itemOrder |
+	itemOrder := aCommandItem order.
+	aCommandItem parentGroup isRoot not & aCommandItem parentGroup isInlined ifTrue: [ 
+		"When we are inlining we should try keep order according to the order of parent.
+		So we just put item order as deimal addition to parent order"
+		itemOrder := aCommandItem parentGroup order + (itemOrder / 10000000.0)].
 	item := (aBuilder item: aCommandItem name)
 		parent: aCommandItem actualParentGroup name;
-		order: aCommandItem order;
+		order: itemOrder;
 		help: aCommandItem description;
 		action: [aCommandItem executeCommand]. 
 	

--- a/Commander-Activators-ContextMenu.package/CmdMenuGroup.extension/instance/registerContextMenuItemsWithBuilder..st
+++ b/Commander-Activators-ContextMenu.package/CmdMenuGroup.extension/instance/registerContextMenuItemsWithBuilder..st
@@ -4,8 +4,10 @@ registerContextMenuItemsWithBuilder: aBuilder
 	self isActive ifFalse: [ ^self ].
 	
 	self isInlined
+		ifTrue: [ aBuilder items ifNotEmpty: [aBuilder withSeparatorAfter] ]
 		ifFalse: [ self registerContextSubMenuWithBuilder: aBuilder].
+		
 	contents do: [ :each | 
 		each registerContextMenuItemsWithBuilder: aBuilder ].
 	
-	"self isInlined ifTrue: [ aBuilder withSeparatorAfter ]"
+	self isInlined ifTrue: [ aBuilder withSeparatorAfter ]


### PR DESCRIPTION
better order of commands injected into pragma based menu as items of inlined group. Now they keep logical order according to the parent inlined group order