### PR TITLE
removeExampleCommandFromWorldMenu

### DIFF
--- a/Commander-Examples.package/CmdOpenFamilyBookCommand.class/class/globalShortcutActivation.st
+++ b/Commander-Examples.package/CmdOpenFamilyBookCommand.class/class/globalShortcutActivation.st
@@ -1,5 +1,7 @@
 activation
 globalShortcutActivation
-	<classAnnotation>
+	"The code is commented to avoid this example command to be global world shortcut.
+	Uncomment following pragma when you want to place with this"
+	"<classAnnotation>"
 	
 	^CmdShortcutCommandActivation by: $o meta, $f meta for: CmdWorldMenuContext 

--- a/Commander-Examples.package/CmdOpenFamilyBookCommand.class/class/worldMenuActivation.st
+++ b/Commander-Examples.package/CmdOpenFamilyBookCommand.class/class/worldMenuActivation.st
@@ -1,5 +1,7 @@
 activation
 worldMenuActivation
-	<classAnnotation>
+	"The code is commented to avoid this example command to be world menu.
+	Uncomment following pragma when you want to place with this"
+	"<classAnnotation>"
 	
 	^CmdContextMenuCommandActivation byRootGroupItemFor: CmdWorldMenuContext 


### PR DESCRIPTION
example global world command is with commented annotations.So it is not shown in world menu by default