### PR TITLE
SpecSupport is in default baseline

### DIFF
--- a/BaselineOfCommander.package/BaselineOfCommander.class/instance/baseline..st
+++ b/BaselineOfCommander.package/BaselineOfCommander.class/instance/baseline..st
@@ -34,4 +34,11 @@ baseline: spec
 			group: 'Core' with: #(#'Commander-Core');
 			group: 'AllActivators' with: #(#'Commander-Activators-Shortcut' #'Commander-Activators-ContextMenu' #'Commander-Activators-DragAndDrop' #'Commander-Activators-WorldMenu' #'Commander-Activators-TextView' #'Commander-Activators-Mouse');
 			group: 'Tests' with: #(#'Commander-Core-Tests' );
-			group: 'default' with: #('Core' 'AllActivators' 'Tests')]
+			group: 'default' with: #('Core' 'AllActivators' 'Tests')].
+		
+		spec for: #'pharo6.x' do: [    
+        self spec70: spec.        
+        spec
+            package: 'Commander-SpecSupport' with: [ 
+                spec requires: #('Spec70Compatibility') ].
+			spec group: 'default' with: [ #('Core' 'AllActivators' #'Commander-SpecSupport' #'Commander-Examples' 'Tests')]] 

--- a/BaselineOfCommander.package/BaselineOfCommander.class/instance/baseline..st
+++ b/BaselineOfCommander.package/BaselineOfCommander.class/instance/baseline..st
@@ -41,4 +41,4 @@ baseline: spec
         spec
             package: 'Commander-SpecSupport' with: [ 
                 spec requires: #('Spec70Compatibility') ].
-			spec group: 'default' with: [ #('Core' 'AllActivators' #'Commander-SpecSupport' #'Commander-Examples' 'Tests')]] 
+			spec group: 'default' with: #('Core' 'AllActivators' #'Commander-SpecSupport' #'Commander-Examples' 'Tests')] 

--- a/BaselineOfCommander.package/BaselineOfCommander.class/instance/spec70..st
+++ b/BaselineOfCommander.package/BaselineOfCommander.class/instance/spec70..st
@@ -1,0 +1,6 @@
+baselines
+spec70: spec
+    "for pharo6 compatibility"
+    spec
+        baseline: 'Spec70Compatibility' 
+        with: [ spec repository: 'github://pharo-contributions/Spec70Compatibility:v1.0.0/src' ]


### PR DESCRIPTION
SpecSupport is in default baseline group with compatibility dependency for Pharo 6