### PR TITLE
Use full shortcut representation for keyText

### DIFF
--- a/src/Commander-Activators-ContextMenu/CmdCommandActivator.extension.st
+++ b/src/Commander-Activators-ContextMenu/CmdCommandActivator.extension.st
@@ -23,9 +23,6 @@ CmdCommandActivator >> setUpShortcutTipForMenuItem: aMenuItemMorph [
 	CmdShortcutActivation 
 		activeInstancesFor: command class inContext: context
 		do: [ :shortcut |  	
-			"this is trick to show shortcut on menu with existing menu support"
-			keyText := String streamContents: [:s | 
-				shortcut keyCombination prettyPrintOn: s].
-			keyText := keyText copyWithout: keyText first.
+			keyText := shortcut keyCombination printString copyReplaceAll: 'Meta' with: OSPlatform current defaultModifier name.
 			aMenuItemMorph keyText: keyText]
 ]

--- a/src/Commander-Activators-ContextMenu/CmdCommandActivator.extension.st
+++ b/src/Commander-Activators-ContextMenu/CmdCommandActivator.extension.st
@@ -23,6 +23,6 @@ CmdCommandActivator >> setUpShortcutTipForMenuItem: aMenuItemMorph [
 	CmdShortcutActivation 
 		activeInstancesFor: command class inContext: context
 		do: [ :shortcut |  	
-			keyText := shortcut keyCombination printString copyReplaceAll: 'Meta' with: OSPlatform current defaultModifier name.
+			keyText := shortcut keyCombination printString copyReplaceAll: KMModifier meta name with: OSPlatform current defaultModifier name.
 			aMenuItemMorph keyText: keyText]
 ]


### PR DESCRIPTION
The previous implementation 
* resulted in `ToggleMenuItemShortcut` using "old style" shortcuts, which was bugging out for some keys (e.g. adding Shift modifier to Delete)
* was stripping multiple modifiers... so ctrl+s and ctrl+shift+s resulted in the same text

(Windows, P6 & P7)

With the previous implementation:
```smalltalk
shortcut := (CmdShortcutActivation by: $r meta shift for: String).

keyText := String streamContents: [:s | shortcut keyCombination prettyPrintOn: s].
keyText := keyText copyWithout: keyText first.

(ToggleMenuItemShortcut owner: nil keyText: keyText) text. "'Ctrl + R'"
"but should have been Ctrl + Shift + R"

shortcut := (CmdShortcutActivation by: Character delete meta for: String).

keyText := String streamContents: [:s | shortcut keyCombination prettyPrintOn: s].
keyText := keyText copyWithout: keyText first.

(ToggleMenuItemShortcut owner: nil keyText: keyText) text. "'Ctrl + Shift + Delete'"
"but should have been Ctrl + Delete"
```

With the new one
```smalltalk
shortcut := (CmdShortcutActivation by: $r meta shift for: String).

keyText := shortcut keyCombination printString copyReplaceAll: KMModifier meta name with: OSPlatform current defaultModifier name.
keyText.

(ToggleMenuItemShortcut owner: nil keyText: keyText) text. "'Ctrl + Shift + R'"

shortcut := (CmdShortcutActivation by: Character delete meta for: String).

keyText := shortcut keyCombination printString copyReplaceAll: KMModifier meta name with: OSPlatform current defaultModifier name.
keyText.

(ToggleMenuItemShortcut owner: nil keyText: keyText) text. "'Ctrl + Delete'"
```