### PR TITLE
commandFailuresHandling

### DIFF
--- a/src/Commander-Core/CmdCommandAborted.class.st
+++ b/src/Commander-Core/CmdCommandAborted.class.st
@@ -7,3 +7,7 @@ Class {
 	#superclass : #Error,
 	#category : #'Commander-Core'
 }
+
+{ #category : #notification }
+CmdCommandAborted >> notifyUserOfCommand: aCommand [
+]

--- a/src/Commander-Core/CmdCommandActivator.class.st
+++ b/src/Commander-Core/CmdCommandActivator.class.st
@@ -128,7 +128,7 @@ CmdCommandActivator >> executeCommand [
 	[self prepareCommandForExecution.
 	context executeCommand: command by: self.
 	self applyCommandResult] 
-		on: CmdCommandAborted do: [ :exc |  ]
+		on: Exception do: [ :exc | self processCommandFailure: exc ]
 ]
 
 { #category : #testing }
@@ -174,4 +174,10 @@ CmdCommandActivator >> printOn: aStream [
 	aStream nextPut: $(.
 	command printOn: aStream.
 	aStream nextPut: $).
+]
+
+{ #category : #execution }
+CmdCommandActivator >> processCommandFailure: anException [
+	
+	context processFailure: anException of: command
 ]

--- a/src/Commander-Core/CmdToolContext.class.st
+++ b/src/Commander-Core/CmdToolContext.class.st
@@ -82,6 +82,11 @@ CmdToolContext >> prepareNewCommand: aCommand [
 	aCommand readParametersFromContext: self
 ]
 
+{ #category : #'command execution' }
+CmdToolContext >> processFailure: anException of: aCommand [
+	anException notifyUserOfCommand: aCommand
+]
+
 { #category : #accessing }
 CmdToolContext >> tool [
 	^ tool

--- a/src/Commander-Core/Exception.extension.st
+++ b/src/Commander-Core/Exception.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : #Exception }
+
+{ #category : #'*Commander-Core' }
+Exception >> notifyUserOfCommand: aCommand [
+
+	self pass
+]


### PR DESCRIPTION
Now command execution method handle any exception and delegate user notification to exception instance. By default it just passes itself which shows debugger in case of arbitrary error. But some  exceptions can override it and notify user about command problems in friendly way.
For example refactoring failures will implement #notifyUserOfCommand: to show warning or confirmation dialog to proceed execution.