### PR TITLE
explicitIsAbstract

### DIFF
--- a/src/Commander-Activators-ContextMenu/CmdOpenContextMenuCommand.class.st
+++ b/src/Commander-Activators-ContextMenu/CmdOpenContextMenuCommand.class.st
@@ -18,6 +18,11 @@ Class {
 	#category : #'Commander-Activators-ContextMenu'
 }
 
+{ #category : #testing }
+CmdOpenContextMenuCommand class >> isAbstract [
+	^self = CmdOpenContextMenuCommand 
+]
+
 { #category : #execution }
 CmdOpenContextMenuCommand >> activationStrategy [
 	"Subclasses should return specific kind of activation strategy

--- a/src/Commander-Core-Tests/CmdAbstractCommandExample.class.st
+++ b/src/Commander-Core-Tests/CmdAbstractCommandExample.class.st
@@ -10,3 +10,8 @@ CmdAbstractCommandExample class >> activationExample1 [
 	
 	^CmdCommandActivationExample for: CmdToolContextStub1
 ]
+
+{ #category : #testing }
+CmdAbstractCommandExample class >> isAbstract [
+	^self = CmdAbstractCommandExample 
+]

--- a/src/Commander-Core-Tests/CmdRootOfCommandExamples.class.st
+++ b/src/Commander-Core-Tests/CmdRootOfCommandExamples.class.st
@@ -7,6 +7,11 @@ Class {
 	#category : #'Commander-Core-Tests'
 }
 
+{ #category : #testing }
+CmdRootOfCommandExamples class >> isAbstract [
+	^self = CmdRootOfCommandExamples 
+]
+
 { #category : #execution }
 CmdRootOfCommandExamples >> readParametersFromContext: aToolContext [
 	savedParametersContext := aToolContext

--- a/src/Commander-Core/CmdCommand.class.st
+++ b/src/Commander-Core/CmdCommand.class.st
@@ -122,10 +122,7 @@ CmdCommand class >> defaultMenuItemName [
 
 { #category : #testing }
 CmdCommand class >> isAbstract [
-	"Commands are abstract if they have subclasses. If you want such command be used as normal one you need override this method like 
-		^self == YourCommandWithSubclasses ifTrue: [ false ] ifFalse: [ super isAbstract ]
-	Without it system will not find command which has subclasses"
-	^self subclasses notEmpty
+	^self = CmdCommand 
 ]
 
 { #category : #execution }


### PR DESCRIPTION
Remove odd idea to define isAbstract as "^self subclasses notEmpty".
It should be always the patter "^self = MyClass".It will be major release because users lick Calypso should be adopted (Iceberg initialy uses correct isAbstract logic)